### PR TITLE
Fix normalize path on windows platform

### DIFF
--- a/src/main/kotlin/com/soywiz/kproject/model/KProjectModel.kt
+++ b/src/main/kotlin/com/soywiz/kproject/model/KProjectModel.kt
@@ -6,7 +6,7 @@ import com.soywiz.kproject.util.*
 import org.gradle.api.initialization.*
 import java.io.*
 
-fun normalizePath(path: String): String = File(path).normalize().toString()
+fun normalizePath(path: String): String = File(path).normalize().toString().replace("\\", "/")
 fun ensureRepo(repo: String): String = normalizePath(repo).also { if (it.count { it == '/' } != 1) error("Invalid repo '$repo'") }
 fun getKProjectDir(): File = File("${System.getProperty("user.home")}/.kproject").also { it.mkdirs() }
 operator fun File.get(path: String): File = File(this, path)


### PR DESCRIPTION
On windows the normalize() function converts slashes to backslashes which destroys the git repo name. Thus converting any '\' to '/' after calling normalize function fixes that.