### PR TITLE
Fix loading sources from git repo

### DIFF
--- a/kproject-common/src/main/kotlin/com/soywiz/kproject/internal/Yaml.kt
+++ b/kproject-common/src/main/kotlin/com/soywiz/kproject/internal/Yaml.kt
@@ -163,6 +163,7 @@ internal object Yaml {
             // Line start
             flush()
             val indentStr = readWhile(Char::isWhitespace).replace("\t", "     ")
+            if (indentStr.contains('\n')) continue@linestart  // ignore empty lines with possible additional indent
             val indent = indentStr.length
             if (indents.isEmpty() || indent > indents.last()) {
                 indents += indent

--- a/kproject-common/src/main/kotlin/com/soywiz/kproject/internal/Yaml.kt
+++ b/kproject-common/src/main/kotlin/com/soywiz/kproject/internal/Yaml.kt
@@ -16,8 +16,8 @@ internal object Yaml {
         else -> str.toIntOrNull() ?: str.toDoubleOrNull() ?: str
     }
 
-    //const val TRACE = true
-    const val TRACE = false
+    const val TRACE = true
+    //const val TRACE = false
     private val EMPTY_SET = setOf<String>()
     private val SET_COMMA_END_ARRAY = setOf(",", "]")
 
@@ -42,10 +42,7 @@ internal object Yaml {
                     list.add(res)
                 } else {
                     if (TRACE) println("${levelStr}CHILD.return: $res")
-                    (res as MutableMap<String, Any?>).forEach { (key, value) ->
-                        if (map != null) { map!![key] = value }
-                    }
-                    return map
+                    return res
                 }
             } else if (lineLevel != null && lineLevel < level) {
                 // parent level

--- a/kproject-common/src/main/kotlin/com/soywiz/kproject/internal/Yaml.kt
+++ b/kproject-common/src/main/kotlin/com/soywiz/kproject/internal/Yaml.kt
@@ -42,7 +42,10 @@ internal object Yaml {
                     list.add(res)
                 } else {
                     if (TRACE) println("${levelStr}CHILD.return: $res")
-                    return res
+                    (res as MutableMap<String, Any?>).forEach { (key, value) ->
+                        if (map != null) { map!![key] = value }
+                    }
+                    return map
                 }
             } else if (lineLevel != null && lineLevel < level) {
                 // parent level

--- a/kproject-common/src/main/kotlin/com/soywiz/kproject/internal/Yaml.kt
+++ b/kproject-common/src/main/kotlin/com/soywiz/kproject/internal/Yaml.kt
@@ -16,8 +16,8 @@ internal object Yaml {
         else -> str.toIntOrNull() ?: str.toDoubleOrNull() ?: str
     }
 
-    const val TRACE = true
-    //const val TRACE = false
+    //const val TRACE = true
+    const val TRACE = false
     private val EMPTY_SET = setOf<String>()
     private val SET_COMMA_END_ARRAY = setOf(",", "]")
 

--- a/kproject-common/src/main/kotlin/com/soywiz/kproject/model/KProjectModel.kt
+++ b/kproject-common/src/main/kotlin/com/soywiz/kproject/model/KProjectModel.kt
@@ -60,7 +60,7 @@ class KSource(
     fun resolveDir(): File {
         return when (parts.first()) {
             "git" -> {
-                val (_, _, repo, path, version) = parts
+                val (_, repo, path, version) = parts
                 //File(kProj.kproject, "modules/korge-dragonbones/v3.2.0")
                 project.settings.ensureGitSources(project.rname, repo, path, version, "src", project.settings.modulesDir)
             }

--- a/kproject-common/src/main/kotlin/com/soywiz/kproject/model/KProjectModel.kt
+++ b/kproject-common/src/main/kotlin/com/soywiz/kproject/model/KProjectModel.kt
@@ -60,7 +60,7 @@ class KSource(
     fun resolveDir(): File {
         return when (parts.first()) {
             "git" -> {
-                val (_, repo, path, version) = parts
+                val (_, _, repo, path, version) = parts
                 //File(kProj.kproject, "modules/korge-dragonbones/v3.2.0")
                 project.settings.ensureGitSources(project.rname, repo, path, version, "src", project.settings.modulesDir)
             }

--- a/kproject-common/src/test/kotlin/com/soywiz/kproject/YamlTest.kt
+++ b/kproject-common/src/test/kotlin/com/soywiz/kproject/YamlTest.kt
@@ -238,6 +238,7 @@ class YamlTest {
 			hello:
 			- a
 			- b
+
 			world:
 			- c
 			- d

--- a/kproject-common/src/test/kotlin/com/soywiz/kproject/YamlTest.kt
+++ b/kproject-common/src/test/kotlin/com/soywiz/kproject/YamlTest.kt
@@ -228,24 +228,34 @@ class YamlTest {
 
     @Test
     fun testMapListIssue() {
+        val testYmlString = """
+            hello:
+            - a
+            
+            - b
+              
+            lineWithSpaces:
+              
+              
+            - aa
+            - bb
+              
+            world:
+            - c
+            - d
+            test:
+              - e
+              - f
+        """.trimIndent()
+        //println("\n\n[[[$testYmlString]]]\n\n")
         assertEquals(
             mapOf(
                 "hello" to listOf("a", "b"),
+                "lineWithSpaces" to listOf("aa", "bb"),
                 "world" to listOf("c", "d"),
                 "test" to listOf("e", "f")
             ),
-            Yaml.decode("""
-			hello:
-			- a
-			- b
-
-			world:
-			- c
-			- d
-			test:
-			- e
-			- f
-		""".trimIndent())
+            Yaml.decode(testYmlString)
         )
     }
 


### PR DESCRIPTION
- Fix added in yaml parser so that it does not overwrite map on root level with a map by a child layer. The returned map will be put into the base map. The problem with loading from git was that the "src" detail was lost when loading the yml file.
- Fix splitting of src details for loading a git repo